### PR TITLE
Reuse Port Socket Option on UDP Sockets and Changed to use MAX SRT Payload Size

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "submodule/CLI11"]
 	path = submodule/CLI11
 	url = https://github.com/CLIUtils/CLI11.git
-[submodule "submodule/srt"]
-	path = submodule/srt
-	url = https://github.com/maxsharabayko/srt.git
 [submodule "submodule/spdlog"]
 	path = submodule/spdlog
 	url = https://github.com/gabime/spdlog.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "submodule/spdlog"]
 	path = submodule/spdlog
 	url = https://github.com/gabime/spdlog.git
+[submodule "submodule/srt"]
+	path = submodule/srt
+	url = https://github.com/swxtchio/srt.git

--- a/xtransmit/udp_socket.cpp
+++ b/xtransmit/udp_socket.cpp
@@ -38,7 +38,7 @@ socket::udp::udp(const UriParser &src_uri)
 	}
 
 	int yes = 1;
-	::setsockopt(m_bind_socket, SOL_SOCKET, SO_REUSEADDR, (const char *)&yes, sizeof yes);
+	::setsockopt(m_bind_socket, SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT, (const char *)&yes, sizeof yes);
 
 	if (!m_blocking_mode)
 	{ // set non-blocking mode


### PR DESCRIPTION
Reuse Port Socket Option on UDP Sockets and Changed to use MAX SRT Payload Size

Submodule is pointed to fork of SRT at a branch at a specific commit used in testing. Updated the MAX payload size for SRT sockets to use